### PR TITLE
Fix python version to only require 3.11.X

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,4 +10,3 @@ pylint = "==2.13"
 
 [requires]
 python_version = "3.11"
-python_full_version = "3.11.0"


### PR DESCRIPTION
Will fix the pipenv to only require 3.11.X instead of 3.11.0